### PR TITLE
ci: update @semantic-release/git to disable assets

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,18 +1,15 @@
 {
-    "tagFormat": "v${version}",
-    "branches": [
-        "main"
-    ],
-    "plugins": [
-        "@semantic-release/commit-analyzer",
-        "@semantic-release/release-notes-generator",
-        "@semantic-release/github",
-        "@semantic-release/git",
-        [
-            "@semantic-release/exec",
-            {
-                "successCmd": "echo \"SEMVER_VERSION=${nextRelease.version}\" >> $GITHUB_ENV"
-            }
-        ]
-    ]
+  "tagFormat": "v${version}",
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/github",
+    ["@semantic-release/git", {
+      "assets": "false"
+    }],
+    ["@semantic-release/exec", {
+      "successCmd": "echo \"SEMVER_VERSION=${nextRelease.version}\" >> $GITHUB_ENV"
+    }]
+  ]
 }


### PR DESCRIPTION
### Description

According to https://github.com/semantic-release/git#readme, the `@semantic-release/git` by default tries to commit some files as part of every release…

![image](https://user-images.githubusercontent.com/29608224/175287107-c3b06853-9991-442c-810d-eba9440c5ac2.png)

I believe this is currently breaking the release pipeline, as we see something is trying to commit back to the main branch in that pipeline, but is blocked by the branch protection rule:

```
[10:31:51 PM] [semantic-release] › ✖  Failed step "prepare" of plugin "@semantic-release/git"
[10:31:51 PM] [semantic-release] › ✖  An error occurred while running semantic-release: Error: Command failed with exit code 1: git push --tags https://github.com/terraform-ibm-modules/terraform-ibm-module-template HEAD:main
warning: not sending a push certificate since the receiving end does not support --signed push
remote: error: GH006: Protected branch update failed for refs/heads/main.        
remote: error: Required status check "call-terraform-ci-pipeline / CI_PIPELINE" is expected. At least 1 approving review is required by reviewers with write access.        
To https://github.com/terraform-ibm-modules/terraform-ibm-module-template
 ! [remote rejected] HEAD -> main (protected branch hook declined)
```

**Tick the relevant boxes:**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples / tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI related update (pipeline, etc)

### Checklist:

- [ ] If relevant, a test for the change has been added / updated as part of this PR.
- [ ] If relevant, documentation for the change has been added / updated as part of this PR.

### Merge:
Merge using "Squash and merge" and ensure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message based on the PR contents (this ultimately determines if a new version of the modules needs to be released, and if so, which semver number should be used).
