### PR TITLE
Add links from readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Create a repository from this repository template by clicking `Use this template
 
 ### Clone the repo and set up your development environment
 
-Locally clone the new repository and set up your development environment by completing the tasks in [coming soon]
+Locally clone the new repository and set up your development environment by completing the tasks in [Local development setup](https://terraform-ibm-modules.github.io/documentation/#/local-dev-setup) in the project documentation.
 
 ### Update the Terraform files
 
@@ -53,7 +53,7 @@ After you implement the logic for your module and create examples and tests, upd
 
 ### Commit your code and submit your module for review
 
-1.  Before you commit any code, review the contributing guidelines [coming soon].
+1.  Before you commit any code, review [Contributing to the IBM Cloud Terraform modules project](https://terraform-ibm-modules.github.io/documentation/#/contribute-module) in the project documentation.
 1.  Create a pull request for review.
 
 ### Post-merge steps
@@ -119,5 +119,6 @@ No outputs.
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 <!-- Leave this section as is so that your module has a link to local development environment set up steps for contributors to follow -->
+
 ## Developing
-To set up your local development environment, see steps [coming soon]
+To set up your local development environment, see [Local development setup](https://terraform-ibm-modules.github.io/documentation/#/local-dev-setup) in the project documentation.


### PR DESCRIPTION
### Description

Updates links from README to documentation in this GH org.

Related to https://github.com/terraform-ibm-modules/documentation/pull/5

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [x] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
